### PR TITLE
Minor Updates.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ilanco/woocommerce-gateway-zcredit",
+    "name": "Activate78/woocommerce-gateway-zcredit",
     "description": "WooCommerce Payment Gateway for ZCredit",
     "type": "wordpress-plugin",
     "authors": [

--- a/includes/class-wc-gateway-zcredit.php
+++ b/includes/class-wc-gateway-zcredit.php
@@ -183,7 +183,17 @@ class WC_Gateway_ZCredit extends WC_Payment_Gateway
             $product = $order->get_product_from_item($item);
             $sku = $product ? $product->get_sku() : '';
             $item_line_total = $order->get_item_subtotal($item, false);
-            $lineItems[] = $this->add_line_item($item['name'], $item['qty'], $item_line_total, $sku);
+            
+           // get image of products 
+           if ( has_post_thumbnail( $product->id ) ) {
+                        $attachment_ids[0] = get_post_thumbnail_id( $product->id );
+                         $attachment = wp_get_attachment_image_src($attachment_ids[0], 'full' ); 
+                         $pic_url = $attachment[0];
+            } else {
+                
+                $pic_url = '';
+            }
+            $lineItems[] = $this->add_line_item($item['name'], $item['qty'], $item_line_total, $sku , $pic_url);
         }
 
         return $lineItems;
@@ -196,20 +206,22 @@ class WC_Gateway_ZCredit extends WC_Payment_Gateway
      * @param  int     $quantity
      * @param  int     $amount
      * @param  string  $item_number
-     *
+     * @param  string  $picture_url
+     * 
      * @return bool successfully added or not
      */
-    protected function add_line_item($item_name, $quantity = 1, $amount = 0, $item_number = '')
+    protected function add_line_item($item_name, $quantity = 1, $amount = 0, $item_number = '',$picture_url)
     {
         $lineItem = new ZCredit\CartItem();
         $lineItem->Name = html_entity_decode(wc_trim_string($item_name ? $item_name : 'Item', 127), ENT_NOQUOTES, 'UTF-8');
-        $lineItem->PictureURL = '';
+        $lineItem->PictureURL = $picture_url;
         $lineItem->SN = $item_number;
         $lineItem->Amount = $quantity;
         $lineItem->ItemPrice = $amount;
 
         return $lineItem;
     }
+
 
     public function handle_wc_api()
     {

--- a/includes/class-wc-gateway-zcredit.php
+++ b/includes/class-wc-gateway-zcredit.php
@@ -191,7 +191,7 @@ class WC_Gateway_ZCredit extends WC_Payment_Gateway
                          $pic_url = $attachment[0];
             } else {
                 
-                $pic_url = '';
+                $pic_url = wc_placeholder_img_src();
             }
             $lineItems[] = $this->add_line_item($item['name'], $item['qty'], $item_line_total, $sku , $pic_url);
         }
@@ -206,8 +206,7 @@ class WC_Gateway_ZCredit extends WC_Payment_Gateway
      * @param  int     $quantity
      * @param  int     $amount
      * @param  string  $item_number
-     * @param  string  $picture_url
-     * 
+     *
      * @return bool successfully added or not
      */
     protected function add_line_item($item_name, $quantity = 1, $amount = 0, $item_number = '',$picture_url)

--- a/includes/class-wc-gateway-zcredit.php
+++ b/includes/class-wc-gateway-zcredit.php
@@ -123,7 +123,7 @@ class WC_Gateway_ZCredit extends WC_Payment_Gateway
 
         $lineItems = $this->get_line_items($order);
 
-        switch ($order->get_order_currency()) {
+        switch ($order->get_currency()) {
             case 'USD':
                 $currency = ZCredit\CurrencyType::USD;
                 $language = ZCredit\Languages::English;
@@ -135,7 +135,7 @@ class WC_Gateway_ZCredit extends WC_Payment_Gateway
                 break;
 
             default:
-                throw new Exception('Currency ' . $order->get_order_currency() . ' not supported.');
+                throw new Exception('Currency ' . $order->get_currency() . ' not supported.');
         }
 
         $url = ZCredit\ZCreditHelper::PayWithInvoice(


### PR DESCRIPTION
Compatibility to wordpress 4.7.3 WooCommerce 3.1.2 

Changes:
'get_order_currency' was deprecated and now is 'get_currency' .

Add-ons:
Added Images of products from order page to ZCredit gateway.